### PR TITLE
using logic gate for control signal amplifier to achieve  ¥4/133/3

### DIFF
--- a/control-signal-amplifier-3.txt
+++ b/control-signal-amplifier-3.txt
@@ -1,4 +1,4 @@
-[name] low power & low lines of Code
+[name] (PLD) Twarmboe
 [puzzle] Sz030
 [production-cost] 400
 [power-usage] 133

--- a/control-signal-amplifier-3.txt
+++ b/control-signal-amplifier-3.txt
@@ -1,0 +1,64 @@
+[name] low power & low lines of Code
+[puzzle] Sz030
+[production-cost] 400
+[power-usage] 133
+[lines-of-code] 3
+
+[traces] 
+......................
+......................
+......................
+......................
+......................
+......................
+...........1C.........
+.......1D4..A.........
+........341574........
+......................
+......................
+......................
+......................
+......................
+
+[chip] 
+[type] NOTE
+[x] 9
+[y] 2
+[code] 
+the OR gate clamps
+our input as
+follows:
+
+0  => 0
+25 => 0
+50 => 100
+
+
+[chip] 
+[type] OR
+[x] 9
+[y] 4
+
+[chip] 
+[type] UC4
+[x] 9
+[y] 6
+[code] 
+  tgt p0 p1
++ mov 50 p1
+  slp 1
+
+[chip] 
+[type] NOTE
+[x] 9
+[y] 8
+[code] 
+MC only has to
+worry about 25=>50
+
+The 'tgt' both
+checks for 25
+and clears p1
+if we were sending
+50 previously.
+


### PR DESCRIPTION
We use an OR logic gate to clamp our input values to 0 and 100.

The tests only use 3 input values (0, 25, 50) after going through the OR they will clamp as follows:

0  => 0
25 => 0
50 => 100

These all match what we want for the output except for 25 => 0. Our MC checks for this case in a strange way that allows us to save an instruction as well as power.

tgt p0 p1 will resolve as follows for the given inputs:

0  => tgt 0 0 => false
25 => tgt 25 0 => true
50 =>tgt 50 100 => false

Because we're checking the value of p1 instead of a constant expression, any value we had been previously sending on p1 will be cleared. This is the equivalent of:

teq p0 25
mov 0 p1

Which means we're saving both an instruction count and power used per loop. We need to clear p1 because if a 0 is sent after a 25 the higher signal we were previously sending will override the 0 being sent by the OR gate.