### PR TITLE
Laser Tag: 172 power

### DIFF
--- a/laser-tag-equipment-3.txt
+++ b/laser-tag-equipment-3.txt
@@ -1,4 +1,4 @@
-[name] low power
+[name] (P) Twarmboe
 [puzzle] Sz048
 [production-cost] 1200
 [power-usage] 172

--- a/laser-tag-equipment-3.txt
+++ b/laser-tag-equipment-3.txt
@@ -1,8 +1,8 @@
 [name] low power
 [puzzle] Sz048
 [production-cost] 800
-[power-usage] 196
-[lines-of-code] 7
+[power-usage] 178
+[lines-of-code] 9
 
 [traces] 
 ......................
@@ -30,13 +30,15 @@
 [x] 15
 [y] 2
 [code] 
-  teq x0 0
-- mov x1 acc
-- slp 1
-+ tlt p0 acc
-+ gen p1 1 1
+  tlt p0 acc
++ mov 100 p1
++ slp 1
++ mov 0 p1
 + sub 1
-- slp 1
+- teq x0 0
+- mov x1 acc
+- slp 2
++ slp 1
 
 [chip] 
 [type] DIAL7

--- a/laser-tag-equipment-3.txt
+++ b/laser-tag-equipment-3.txt
@@ -1,7 +1,7 @@
 [name] low power
 [puzzle] Sz048
-[production-cost] 1000
-[power-usage] 177
+[production-cost] 1400
+[power-usage] 172
 [lines-of-code] 10
 
 [traces] 
@@ -10,24 +10,33 @@
 ......................
 ......................
 ......................
-..94141C........955C..
-..A.94.A........A..A..
-..2.35CA.....9556..2..
-..15416A.....A955414..
-..1D4..A...95634.15C..
-...3555E...34......2..
-.......355554154.14...
+..94141C...95555555C..
+..A.94.A...A955554.A..
+..2.35CA...AA..1C..2..
+..15416A...AA...A.14..
+..1D4..A.95634.1E.1C..
+...3555E.34.....34.2..
+.......3554154.14.....
 ......................
 ......................
 
 [chip] 
+[type] NOTE
+[x] 18
+[y] 1
+[code] 
+OR prevents value
+of 1 from going
+through
+
+[chip] 
 [type] AND
-[x] 12
+[x] 10
 [y] 2
 
 [chip] 
 [type] UC6
-[x] 15
+[x] 13
 [y] 2
 [code] 
 - teq x0 0
@@ -38,15 +47,18 @@
   tlt p0 acc
 + mov 100 p1
 + slp 1
-+ mov 0 p1
-+ sub 1
-  
++ sub p1 #clr p1
 
 [chip] 
 [type] DIAL7
-[x] 18
+[x] 16
 [y] 2
 [is-puzzle-provided] true
+
+[chip] 
+[type] OR
+[x] 17
+[y] 3
 
 [chip] 
 [type] OR
@@ -55,13 +67,21 @@
 
 [chip] 
 [type] NOTE
-[x] 11
+[x] 9
 [y] 4
 [code] 
 AND gate only
 allows a shot
 while alive and
 pulling trigger
+
+[chip] 
+[type] UC4
+[x] 13
+[y] 5
+[code] 
+@ mov 1 p1
+#free slp
 
 [chip] 
 [type] DX3
@@ -75,7 +95,7 @@ pulling trigger
 
 [chip] 
 [type] NOTE
-[x] 8
+[x] 7
 [y] 7
 [code] 
 SR Latch takes

--- a/laser-tag-equipment-3.txt
+++ b/laser-tag-equipment-3.txt
@@ -1,6 +1,6 @@
 [name] low power
 [puzzle] Sz048
-[production-cost] 1400
+[production-cost] 1200
 [power-usage] 172
 [lines-of-code] 10
 
@@ -11,11 +11,11 @@
 ......................
 ......................
 ..94141C...95555555C..
-..A.94.A...A955554.A..
-..2.35CA...AA..1C..2..
-..15416A...AA...A.14..
-..1D4..A.95634.1E.1C..
-...3555E.34.....34.2..
+..A.94.A...A.......A..
+..2.35CA...A955554.2..
+..15416A...AA..1C.14..
+..1D4..A.956A...A.1C..
+...3555E.34.34.174.2..
 .......3554154.14.....
 ......................
 ......................
@@ -27,7 +27,7 @@
 [code] 
 OR prevents value
 of 1 from going
-through
+through to fire
 
 [chip] 
 [type] AND
@@ -35,13 +35,13 @@ through
 [y] 2
 
 [chip] 
-[type] UC6
+[type] UC4
 [x] 13
 [y] 2
 [code] 
 - teq x0 0
 @ teq x0 0
-- mov x2 acc
+- mov x1 acc
 - slp 2
 + slp 1
   tlt p0 acc
@@ -78,7 +78,7 @@ pulling trigger
 [chip] 
 [type] UC4
 [x] 13
-[y] 5
+[y] 4
 [code] 
 @ mov 1 p1
 #free slp

--- a/laser-tag-equipment-3.txt
+++ b/laser-tag-equipment-3.txt
@@ -1,8 +1,8 @@
 [name] low power
 [puzzle] Sz048
-[production-cost] 800
-[power-usage] 178
-[lines-of-code] 9
+[production-cost] 1000
+[power-usage] 177
+[lines-of-code] 10
 
 [traces] 
 ......................
@@ -10,35 +10,37 @@
 ......................
 ......................
 ......................
-..94141C..............
-..A.94.A........955C..
-..2.35CA........A..2..
-..15416A..9555556.14..
-..1D4..A..A...9554....
-...3555E..34..34.154..
-.......355541554.14...
+..94141C........955C..
+..A.94.A........A..A..
+..2.35CA.....9556..2..
+..15416A.....A955414..
+..1D4..A...95634.15C..
+...3555E...34......2..
+.......355554154.14...
 ......................
 ......................
 
 [chip] 
 [type] AND
-[x] 11
+[x] 12
 [y] 2
 
 [chip] 
-[type] UC4
+[type] UC6
 [x] 15
 [y] 2
 [code] 
+- teq x0 0
+@ teq x0 0
+- mov x2 acc
+- slp 2
++ slp 1
   tlt p0 acc
 + mov 100 p1
 + slp 1
 + mov 0 p1
 + sub 1
-- teq x0 0
-- mov x1 acc
-- slp 2
-+ slp 1
+  
 
 [chip] 
 [type] DIAL7
@@ -64,7 +66,7 @@ pulling trigger
 [chip] 
 [type] DX3
 [x] 17
-[y] 4
+[y] 5
 
 [chip] 
 [type] AND
@@ -83,15 +85,15 @@ without need of
 an MC
 
 [chip] 
-[type] NOTE
-[x] 17
-[y] 7
-[code] 
-DX300 only for
-simple => xbus
-
-[chip] 
 [type] NOT
 [x] 3
 [y] 8
+
+[chip] 
+[type] NOTE
+[x] 17
+[y] 8
+[code] 
+DX300 only for
+simple => xbus
 


### PR DESCRIPTION
solution is now ¥10/**177**/10

Made further power improvements by:

* Switching around the loop so that reload is only checked after checking if a trigger has been pulled (valid trigger inputs are far more common than reload inputs, and they never occur on the same tick). The exception to this is on the first tick we will only check the reload since a trigger action on the first tick will never result in a shot.

* Breaking up the gen instruction such that we can share the slp 1 instruction with the not firing and not reloading path.

* A reload instruction now sleeps with a slp 2 instruction instead of two slp 1 instructions which will save 1 power per reload.