### PR TITLE
Laser tag 6 cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Harmonic Maximization Engine      | 0 Thaui 4/285/7        | 0 Thaui 4/285/7    
 Passive Infrared Sensor           | 1 Thaui 6/296/10       | 4 CaitSith2 12/182/19  | 3 CaitSith2 6/301/7    | 5 Thaui 6/301/7
 Virtual Reality Buzzer            | 0 Thaui 3/134/6        | 6 Twarmboe 9/85/14     | 7 Twarmboe 14/721/2    | 5 Thaui 6/177/3
 Wireless Game Controller          | 4 Thaui 6/244/9        | 3 CaitSith2 8/99/8     | 4 CaitSith2 8/190/6    | 3 CaitSith2 8/99/8
-Laser Tag Equipment               | 0 Thaui 7/399/13       | 3 Twarmboe 12/172/10   | 7 CaitSith2 14/281/5   | 0 Thaui 7/399/13
+Laser Tag Equipment               | 8 Twarmboe 6/219/9     | 3 Twarmboe 12/172/10   | 7 CaitSith2 14/281/5   | 0 Thaui 7/399/13
 Color Changing Vape Pen           | 3 CaitSith2 8/221/15   | 3 CaitSith2 8/221/15   | 4 CaitSith2 8/234/13   | 0 Thaui 9/357/23
 Unknown Optimization Device       | 0 CaitSith2 6/655/13   | 0 CaitSith2 6/655/13   | 0 CaitSith2 6/655/13   | 0 CaitSith2 6/655/13
 Token-Based Payment Kiosk         | 0 CaitSith2 9/327/22   | 1 CaitSith2 16/268/26  | 2 CaitSith2 14/299/18  | 2 CaitSith2 14/299/18

--- a/laser-tag-equipment-8.txt
+++ b/laser-tag-equipment-8.txt
@@ -1,0 +1,68 @@
+[name] (C) Twarmboe
+[puzzle] Sz048
+[production-cost] 600
+[power-usage] 219
+[lines-of-code] 9
+
+[traces] 
+......................
+......................
+......................
+......................
+......................
+..954.................
+..A9415C.........14...
+..2355C2.........154..
+..154.B5C.....954.14..
+..1D4168A.....A.......
+...35556A.....34.154..
+........35555554.14...
+......................
+......................
+
+[chip] 
+[type] UC4
+[x] 15
+[y] 2
+[code] 
+@ mov 100 p0
+  tlt x0 99
+- mov x1 acc
+@ mov 0 p0
++ teq x0 10
++ tlt p0 acc
++ gen p1 1 1
++ sub 1
+- slp 1
+
+[chip] 
+[type] DIAL7
+[x] 18
+[y] 2
+[is-puzzle-provided] true
+
+[chip] 
+[type] OR
+[x] 4
+[y] 4
+
+[chip] 
+[type] BRIDGE
+[x] 7
+[y] 4
+
+[chip] 
+[type] DX3
+[x] 16
+[y] 5
+
+[chip] 
+[type] BRIDGE
+[x] 18
+[y] 5
+
+[chip] 
+[type] OR
+[x] 4
+[y] 7
+


### PR DESCRIPTION
Solution is: ¥**6**/219/9

We use a double NOR SR latch instead of an NOT, AND, OR SR latch to reduce cost to ¥6. The problem with this kind of latch is it has an indeterminate initial state so we have to use two @ instructions (strategically placed) so that we correctly initialize as dead on the first cycle. Otherwise it will break on a later test run where one of the other gates gets priority and we start off as alive. 

The AND gate is also removed since we can just run an additional test instruction when wiring trigger into the DX300.