### PR TITLE
Laser Tag: 140 power

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Harmonic Maximization Engine      | 0 Thaui 4/285/7        | 0 Thaui 4/285/7    
 Passive Infrared Sensor           | 1 Thaui 6/296/10       | 4 CaitSith2 12/182/19  | 3 CaitSith2 6/301/7    | 5 Thaui 6/301/7
 Virtual Reality Buzzer            | 0 Thaui 3/134/6        | 6 Twarmboe 9/85/14     | 7 Twarmboe 14/721/2    | 5 Thaui 6/177/3
 Wireless Game Controller          | 4 Thaui 6/244/9        | 3 CaitSith2 8/99/8     | 4 CaitSith2 8/190/6    | 3 CaitSith2 8/99/8
-Laser Tag Equipment               | 8 Twarmboe 6/219/9     | 3 Twarmboe 12/172/10   | 7 CaitSith2 14/281/5   | 0 Thaui 7/399/13
+Laser Tag Equipment               | 8 Twarmboe 6/219/9     | 9 Twarmboe 14/140/8    | 7 CaitSith2 14/281/5   | 0 Thaui 7/399/13
 Color Changing Vape Pen           | 3 CaitSith2 8/221/15   | 3 CaitSith2 8/221/15   | 4 CaitSith2 8/234/13   | 0 Thaui 9/357/23
 Unknown Optimization Device       | 0 CaitSith2 6/655/13   | 0 CaitSith2 6/655/13   | 0 CaitSith2 6/655/13   | 0 CaitSith2 6/655/13
 Token-Based Payment Kiosk         | 0 CaitSith2 9/327/22   | 1 CaitSith2 16/268/26  | 2 CaitSith2 14/299/18  | 2 CaitSith2 14/299/18

--- a/laser-tag-equipment-9.txt
+++ b/laser-tag-equipment-9.txt
@@ -1,0 +1,93 @@
+[name] (P) Twarmboe
+[puzzle] Sz048
+[production-cost] 1400
+[power-usage] 140
+[lines-of-code] 8
+
+[traces] 
+......................
+......................
+......................
+......................
+......................
+..94949555555555555C..
+..A161E955555555C.16..
+..21C.A34..955C.3414..
+..1434A94156..A15554..
+..1D496A14....35415C..
+...356161414.14....2..
+.............14.......
+......................
+......................
+
+[chip] 
+[type] DX3
+[x] 9
+[y] 2
+[rotated] true
+
+[chip] 
+[type] UC6
+[x] 11
+[y] 2
+[code] 
+  tcp x3 10
+- sub 1
+- slp 1
+- mov acc x1
++ mov x2 acc
++ slp 1
++ mov acc x1
+  slp 1
+  
+  
+  
+
+[chip] 
+[type] DIAL7
+[x] 14
+[y] 2
+[is-puzzle-provided] true
+
+[chip] 
+[type] OR
+[x] 7
+[y] 3
+[rotated] true
+
+[chip] 
+[type] DX3
+[x] 14
+[y] 3
+
+[chip] 
+[type] OR
+[x] 3
+[y] 4
+
+[chip] 
+[type] NOT
+[x] 16
+[y] 4
+
+[chip] 
+[type] AND
+[x] 8
+[y] 5
+
+[chip] 
+[type] AND
+[x] 4
+[y] 6
+
+[chip] 
+[type] AND
+[x] 17
+[y] 6
+[rotated] true
+
+[chip] 
+[type] NOT
+[x] 3
+[y] 8
+


### PR DESCRIPTION
Solution is now: ¥14/**140**/8

Taking a slightly different approach here where instead of generating our pulse we passively let it through
using an AND gate.

We also use a DX300 to turn the ammo count into a high/low signal (high for anything besides 0, values of 100+ aren't possible) to be ANDed with the trigger_and_alive signal.

I'm also wiring both the fire output (negated) and the reload output into another DX300 so I can do a tcp against 10 (where 0 is firing, 10 is nop, 100 is reload). This may not actually be optimal as I suspect there's a better way to spend that precious space.

This is not the lowest known solution; there's a 122 power solution somewhere in the wild.